### PR TITLE
Fixed `CompanionType` enumeration values

### DIFF
--- a/Sources/OpenRTB/OpenRTB2+Video.swift
+++ b/Sources/OpenRTB/OpenRTB2+Video.swift
@@ -110,13 +110,13 @@ extension OpenRTB2 {
     /// - Note: Conforms to OpenRTB 2.5 specification 5.14
     public enum CompanionType: Int, Codable {
         /// Static Resource
-        case staticResource
+        case staticResource = 1
         
         /// HTML Resource
-        case htmlResource
+        case htmlResource = 2
         
         /// iframe Resource
-        case iframeResource
+        case iframeResource = 3
     }
     
     /// The following enumeration lists the various options for the delivery of video or audio content.


### PR DESCRIPTION
Fixed a bug where the `CompanionType` enumeration starts at 0 instead of 1 per section 5.14 of the OpenRTB 2.5 spec.